### PR TITLE
fix(NET-271): correct network model type, display default acl

### DIFF
--- a/src/models/Network.ts
+++ b/src/models/Network.ts
@@ -20,7 +20,7 @@ export interface Network {
   defaultnatenabled: boolean;
   defaultextclientdns: string;
   defaultmtu: number;
-  defaultacl: boolean;
+  defaultacl: 'yes' | 'no';
   prosettings: ProSettings | undefined;
 }
 
@@ -30,6 +30,5 @@ export type NetworkPayload = Modify<
     isipv4: 'no' | 'yes';
     isipv6: 'no' | 'yes';
     defaultudpholepunch: 'no' | 'yes';
-    defaultacl: 'no' | 'yes';
   }
 >;

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -25,7 +25,6 @@ export function convertUiNetworkToNetworkPayload(network: Network): NetworkPaylo
     isipv4: network.isipv4 ? 'yes' : 'no',
     isipv6: network.isipv6 ? 'yes' : 'no',
     defaultudpholepunch: network.defaultudpholepunch ? 'yes' : 'no',
-    defaultacl: network.defaultacl ? 'yes' : 'no',
     prosettings: network.prosettings
       ? {
           defaultaccesslevel: Number(network.prosettings.defaultaccesslevel),
@@ -47,7 +46,6 @@ export function convertNetworkPayloadToUiNetwork(network: NetworkPayload): Netwo
     isipv4: network.isipv4 === 'yes',
     isipv6: network.isipv6 === 'yes',
     defaultudpholepunch: network.defaultudpholepunch === 'yes',
-    defaultacl: network.defaultacl === 'yes',
     prosettings: network.prosettings
       ? {
           defaultaccesslevel: Number(network.prosettings.defaultaccesslevel),


### PR DESCRIPTION
![image](https://github.com/gravitl/netmaker-ui-2/assets/8738443/4b70c420-cb88-4819-9842-7c199d478ed7)
