### PR TITLE
fix(NET-626): fix logic to determine relays

### DIFF
--- a/src/constants/Types.ts
+++ b/src/constants/Types.ts
@@ -58,6 +58,8 @@ export const NULL_NODE: Node = {
   relayedby: '',
   relaynodes: [],
   autoupdate: false,
+  isrelay: false,
+  isrelayed: false,
 };
 
 export const NULL_NETWORK_PROSETTINGS: ProSettings = {

--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -29,6 +29,8 @@ export interface Node {
   defaultacl: string;
   connected: boolean;
   failover: boolean;
+  isrelay: boolean;
+  isrelayed: boolean;
   relayedby: Node['id'];
   relaynodes?: Node['id'][];
   autoupdate: boolean;

--- a/src/tests/fixtures/Models.ts
+++ b/src/tests/fixtures/Models.ts
@@ -133,6 +133,8 @@ export const stubNode1: Node = {
   failover: false,
   relayedby: '',
   autoupdate: false,
+  isrelay: false,
+  isrelayed: false,
 };
 
 export const stubNode2: Node = {
@@ -166,6 +168,8 @@ export const stubNode2: Node = {
   failover: false,
   relayedby: '',
   autoupdate: false,
+  isrelay: false,
+  isrelayed: false,
 };
 
 export const stubNodes: Node[] = [stubNode1, stubNode2];

--- a/src/tests/utils/NodeUtils.test.ts
+++ b/src/tests/utils/NodeUtils.test.ts
@@ -34,6 +34,8 @@ const testNode: Node = {
   relayedby: '',
   relaynodes: [],
   autoupdate: false,
+  isrelay: false,
+  isrelayed: false,
 };
 
 const hostRegistry: Record<Host['id'], HostCommonDetails> = {

--- a/src/tests/utils/Utils.test.tsx
+++ b/src/tests/utils/Utils.test.tsx
@@ -44,6 +44,8 @@ const testNode1: Node = {
   relayedby: '',
   relaynodes: [],
   autoupdate: false,
+  isrelay: false,
+  isrelayed: false,
 };
 
 const testNode2 = { ...testNode1, lastcheckin: testNode1.lastcheckin - 400 };

--- a/src/utils/NodeUtils.ts
+++ b/src/utils/NodeUtils.ts
@@ -50,8 +50,7 @@ export function getExtendedNode(node: Node, hostCommonDetails: Record<string, Ho
  * @returns whether node is a relay or not
  */
 export function isNodeRelay(node: Node): boolean {
-  if (node.relaynodes) return node.relaynodes.length > 0;
-  return false;
+  return !!node.isrelay;
 }
 
 /**


### PR DESCRIPTION
fixes situation where user can't re-add relay after removing "node is already a relay"