### PR TITLE
Kwesi/net-1208-ui-remove-download-link-for-linux-rac-point-to-docs

### DIFF
--- a/src/components/modals/add-hosts-to-network-modal/AddHostsToNetworkModal.tsx
+++ b/src/components/modals/add-hosts-to-network-modal/AddHostsToNetworkModal.tsx
@@ -113,8 +113,12 @@ export default function AddHostsToNetworkModal({
                     defaultSortOrder: 'ascend',
                   },
                   {
-                    title: 'Endpoint',
+                    title: 'Endpoint (IPv4)',
                     dataIndex: 'endpointip',
+                  },
+                  {
+                    title: 'Endpoint (IPv6)',
+                    dataIndex: 'endpointipv6',
                   },
                   {
                     title: 'Public Port',

--- a/src/components/modals/quick-setup-modal/QuickSetupModal.tsx
+++ b/src/components/modals/quick-setup-modal/QuickSetupModal.tsx
@@ -1,4 +1,4 @@
-import { CloseOutlined, LockOutlined, PlusOutlined, SelectOutlined } from '@ant-design/icons';
+import { CloseOutlined, PlusOutlined } from '@ant-design/icons';
 import {
   Col,
   Row,
@@ -16,7 +16,7 @@ import {
   Alert,
 } from 'antd';
 import { useStore } from '@/store/store';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   UsecaseQuestionsAll,
   UsecaseQuestions,
@@ -36,7 +36,7 @@ import { isValidIpCidr } from '@/utils/NetworkUtils';
 import { INTERNET_RANGE_IPV4, INTERNET_RANGE_IPV6 } from '@/constants/AppConstants';
 import { UsecaseQuestionAndAnswer } from '@/store/networkusecase';
 import AddHostsToNetworkModal from '../add-hosts-to-network-modal/AddHostsToNetworkModal';
-import { Links, Images } from '@/constants/LinkAndImageConstants';
+import { ExternalLinks, AppImages } from '@/constants/LinkAndImageConstants';
 
 interface ModalProps {
   isModalOpen: boolean;
@@ -343,11 +343,11 @@ export default function QuickSetupModal(props: ModalProps) {
     if (window.innerWidth <= 768) return <></>;
     let img = null;
     if (currentQuestion.key === 'egress') {
-      img = Images.EGRESS_IMG;
+      img = AppImages.EGRESS_IMG;
     } else if (currentQuestion.key === 'remote_access_gateways') {
-      img = Images.RAG_IMG;
+      img = AppImages.RAG_IMG;
     } else if (currentQuestion.key === 'networks') {
-      img = Images.NET_IMG;
+      img = AppImages.NET_IMG;
     } else {
       return <></>;
     }
@@ -383,7 +383,7 @@ export default function QuickSetupModal(props: ModalProps) {
             message={
               <>
                 Visit{' '}
-                <a href={Links.RAC_LINK} target="_blank" rel="noreferrer">
+                <a href={ExternalLinks.RAC_LINK} target="_blank" rel="noreferrer">
                   our docs{' '}
                 </a>{' '}
                 to find out how to use the Remote Access Client
@@ -398,7 +398,7 @@ export default function QuickSetupModal(props: ModalProps) {
             message={
               <>
                 Visit{' '}
-                <a href={Links.WIREGUARD_LINK} target="_blank" rel="noreferrer">
+                <a href={ExternalLinks.WIREGUARD_LINK} target="_blank" rel="noreferrer">
                   our docs{' '}
                 </a>{' '}
                 to find out how to use the vpn client with wireguard

--- a/src/components/modals/remote-access-client-modal/DownloadRemoteAccessClientModal.tsx
+++ b/src/components/modals/remote-access-client-modal/DownloadRemoteAccessClientModal.tsx
@@ -1,33 +1,11 @@
-import {
-  ArrowLeftOutlined,
-  ArrowRightOutlined,
-  CloseOutlined,
-  QuestionCircleOutlined,
-  SearchOutlined,
-} from '@ant-design/icons';
+import { QuestionCircleOutlined } from '@ant-design/icons';
 import '../CustomModal.scss';
 import './DownloadRemoteAccessClientModal.scss';
-import {
-  Alert,
-  Button,
-  Card,
-  Col,
-  Divider,
-  Form,
-  Input,
-  Modal,
-  Row,
-  Select,
-  Steps,
-  Table,
-  Typography,
-  notification,
-} from 'antd';
-import { MouseEvent, Ref, useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Card, Col, Divider, Form, Modal, Row, Select } from 'antd';
+import { MouseEvent, useCallback, useEffect, useState } from 'react';
 import { useStore } from '@/store/store';
 import { AvailableArchs, AvailableOses } from '@/models/AvailableOses';
-import { getNetclientDownloadLink, getRACDownloadLink } from '@/utils/RouteUtils';
-import { EnrollmentKey } from '@/models/EnrollmentKey';
+import { getRACDownloadLink } from '@/utils/RouteUtils';
 import { isSaasBuild } from '@/services/BaseService';
 import { ServerConfigService } from '@/services/ServerConfigService';
 
@@ -44,22 +22,12 @@ interface DownloadRemoteAccessClientModalProps {
 
 const RAC_DOCS_URL = 'https://docs.netmaker.io/pro/rac.html';
 
-export default function DownloadRemotesAccessClientModal({
-  isOpen,
-  onCancel,
-  networkId,
-}: DownloadRemoteAccessClientModalProps) {
+export default function DownloadRemotesAccessClientModal({ isOpen, onCancel }: DownloadRemoteAccessClientModalProps) {
   const store = useStore();
-  const [notify, notifyCtx] = notification.useNotification();
 
   const theme = store.currentTheme;
-  const [currentStep, setCurrentStep] = useState(0);
-  const [keySearch, setKeySearch] = useState('');
   const [selectedOs, setSelectedOs] = useState<AvailableOses>('windows');
   const [selectedArch, setSelectedArch] = useState<AvailableArchs>('amd64');
-  const [enrollmentKeys, setEnrollmentKeys] = useState<EnrollmentKey[]>([]);
-  const [selectedEnrollmentKey, setSelectedEnrollmentKey] = useState<EnrollmentKey | null>(null);
-  const [isAddEnrollmentKeyModalOpen, setIsAddEnrollmentKeyModalOpen] = useState(false);
 
   const onShowInstallGuide = useCallback((ev: MouseEvent, os: AvailableOses) => {
     const btnSelector = '.NewHostModal .os-button';
@@ -72,9 +40,6 @@ export default function DownloadRemotesAccessClientModal({
   }, []);
 
   const resetModal = () => {
-    setCurrentStep(0);
-    setIsAddEnrollmentKeyModalOpen(false);
-    setSelectedEnrollmentKey(null);
     setSelectedOs('windows');
     setSelectedArch('amd64');
   };
@@ -245,8 +210,6 @@ export default function DownloadRemotesAccessClientModal({
           </Col>
         </Row>
       </div>
-      {/* misc */}
-      {notifyCtx}
     </Modal>
   );
 }

--- a/src/components/modals/remote-access-client-modal/DownloadRemoteAccessClientModal.tsx
+++ b/src/components/modals/remote-access-client-modal/DownloadRemoteAccessClientModal.tsx
@@ -186,7 +186,7 @@ export default function DownloadRemotesAccessClientModal({ isOpen, onCancel }: D
                           options={[{ label: 'AMD64', value: 'amd64' }]}
                         ></Select>
                       </Form.Item>
-                      <Button
+                      {/* <Button
                         type="primary"
                         href={getRACDownloadLink('linux', selectedArch, 'gui')[0]}
                         block
@@ -196,9 +196,9 @@ export default function DownloadRemotesAccessClientModal({ isOpen, onCancel }: D
                         Download Installer
                       </Button>
 
-                      <Divider />
+                      <Divider /> */}
                       <div className="" style={{ marginTop: '1rem', textAlign: 'center' }}>
-                        <Button type="link" href={RAC_DOCS_URL} target="_blank" rel="noreferrer">
+                        <Button type="primary" block href={RAC_DOCS_URL} target="_blank" rel="noreferrer">
                           View Docs
                         </Button>
                       </div>

--- a/src/components/modals/update-host-modal/UpdateHostModal.tsx
+++ b/src/components/modals/update-host-modal/UpdateHostModal.tsx
@@ -116,10 +116,19 @@ export default function UpdateHostModal({ isOpen, host, onUpdateHost, onCancel }
             </Form.Item>
 
             <Form.Item
-              label="Endpoint IP"
+              label="Endpoint IP (IPv4)"
               name="endpointip"
               rules={[{ required: isStaticVal }]}
               data-nmui-intercom="update-host-form_endpointip"
+            >
+              <Input placeholder="Endpoint IP" disabled={!isStaticVal} />
+            </Form.Item>
+
+            <Form.Item
+              label="Endpoint IP (IPv6)"
+              name="endpointipv6"
+              rules={[{ required: isStaticVal }]}
+              data-nmui-intercom="update-host-form_endpointipv6"
             >
               <Input placeholder="Endpoint IP" disabled={!isStaticVal} />
             </Form.Item>

--- a/src/components/modals/update-node-modal/UpdateNodeModal.tsx
+++ b/src/components/modals/update-node-modal/UpdateNodeModal.tsx
@@ -16,7 +16,6 @@ import { MouseEvent } from 'react';
 import { useStore } from '@/store/store';
 import '../CustomModal.scss';
 import { extractErrorMsg } from '@/utils/ServiceUtils';
-import { Host } from '@/models/Host';
 import { Node } from '@/models/Node';
 import { getHostRoute } from '@/utils/RouteUtils';
 import { NodesService } from '@/services/NodesService';
@@ -37,7 +36,6 @@ export default function UpdateNodeModal({ isOpen, node, onUpdateNode, onCancel }
   const navigate = useNavigate();
 
   const storeUpdateNode = store.updateNode;
-  const isStaticVal: Host['isstatic'] = Form.useWatch('isstatic', form);
 
   const network = store.networks.find((n) => n.netid === node.network);
   const host = store.hosts.find((h) => h.id === node.hostid);
@@ -94,7 +92,12 @@ export default function UpdateNodeModal({ isOpen, node, onUpdateNode, onCancel }
         name="update-node-form"
         form={form}
         layout="vertical"
-        initialValues={{ ...node, expdatetime: dayjs(node.expdatetime * 1000), endpointip: host?.endpointip ?? '' }}
+        initialValues={{
+          ...node,
+          expdatetime: dayjs(node.expdatetime * 1000),
+          endpointip: host?.endpointip ?? '',
+          endpointipv6: host?.endpointipv6 ?? '',
+        }}
       >
         <div className="scrollable-modal-body">
           <div className="CustomModalBody">
@@ -146,17 +149,12 @@ export default function UpdateNodeModal({ isOpen, node, onUpdateNode, onCancel }
               />
             </Form.Item>
 
-            <Form.Item
-              label="Endpoint IP"
-              name="endpointip"
-              rules={[{ required: isStaticVal }]}
-              data-nmui-intercom="update-node-form_endpointip"
-            >
-              <Input
-                placeholder="Endpoint IP"
-                disabled={!isStaticVal}
-                title="To edit, click Global Host Settings below"
-              />
+            <Form.Item label="Endpoint IP (IPv4)" name="endpointip" data-nmui-intercom="update-node-form_endpointip">
+              <Input placeholder="Endpoint IP" disabled title="To edit, click Global Host Settings below" />
+            </Form.Item>
+
+            <Form.Item label="Endpoint IP (IPv6)" name="endpointipv6" data-nmui-intercom="update-node-form_endpointip">
+              <Input placeholder="Endpoint IP" disabled title="To edit, click Global Host Settings below" />
             </Form.Item>
 
             <Form.Item

--- a/src/components/modals/upgrade-modal/UpgradeModal.tsx
+++ b/src/components/modals/upgrade-modal/UpgradeModal.tsx
@@ -3,7 +3,7 @@ import { MouseEvent } from 'react';
 import '../CustomModal.scss';
 import { getAmuiUrl, getLicenseDashboardUrl } from '@/utils/RouteUtils';
 import { isSaasBuild } from '@/services/BaseService';
-import { Links } from '@/constants/LinkAndImageConstants';
+import { ExternalLinks } from '@/constants/LinkAndImageConstants';
 
 interface UpgradeModalProps {
   isOpen: boolean;
@@ -38,7 +38,7 @@ export default function UpgradeModal({ isOpen, onUpgrade: onOk, onCancel }: Upgr
         {!isSaasBuild && (
           <p>
             Visit{' '}
-            <a href={Links.PRO_UPGRADE_DOCS_LINK} target="_blank" rel="noreferrer">
+            <a href={ExternalLinks.PRO_UPGRADE_DOCS_LINK} target="_blank" rel="noreferrer">
               our upgrade docs
             </a>{' '}
             for more information on how to upgrade.

--- a/src/constants/LinkAndImageConstants.ts
+++ b/src/constants/LinkAndImageConstants.ts
@@ -1,18 +1,20 @@
 const RAC_LINK = 'https://docs.netmaker.io/pro/rac.html';
 const WIREGUARD_LINK = 'https://docs.netmaker.io/integrating-non-native-devices.html';
 const PRO_UPGRADE_DOCS_LINK = 'https://docs.netmaker.io/pro/pro-setup.html';
+const RAC_DOWNLOAD_DOCS_LINK = 'https://docs.netmaker.io/pro/rac.html#download-installation';
 
 const EGRESS_IMG = '/egress.webp';
 const RAG_IMG = '/rag.webp';
 const NET_IMG = '/network.webp';
 
-export const Links = {
+export const ExternalLinks = {
   RAC_LINK,
   WIREGUARD_LINK,
   PRO_UPGRADE_DOCS_LINK,
+  RAC_DOWNLOAD_DOCS_LINK,
 };
 
-export const Images = {
+export const AppImages = {
   EGRESS_IMG,
   RAG_IMG,
   NET_IMG,

--- a/src/pages/networks/NetworkDetailsPage.tsx
+++ b/src/pages/networks/NetworkDetailsPage.tsx
@@ -103,7 +103,7 @@ import { AvailableOses } from '@/models/AvailableOses';
 import { NetworkUsage, networkUsecaseMap } from '@/constants/NetworkUseCases';
 import { NetworkUsecaseString } from '@/store/networkusecase';
 import QuickSetupModal from '@/components/modals/quick-setup-modal/QuickSetupModal';
-import { ExternalLinks } from '@/constants/LinkAndImageConstants';
+import DownloadRemotesAccessClientModal from '@/components/modals/remote-access-client-modal/DownloadRemoteAccessClientModal';
 
 interface ExternalRoutesTableData {
   node: ExtendedNode;
@@ -2473,7 +2473,8 @@ export default function NetworkDetailsPage(props: PageProps) {
                     (Android, iOS) operating systems.
                   </span>
                   <Button
-                    href={ExternalLinks.RAC_DOWNLOAD_DOCS_LINK}
+                    // href={ExternalLinks.RAC_DOWNLOAD_DOCS_LINK}
+                    onClick={() => setIsDownloadRemoteAccessClientModalOpen(true)}
                     target="_blank"
                     rel="noreferrer"
                     type="primary"
@@ -4216,6 +4217,11 @@ export default function NetworkDetailsPage(props: PageProps) {
             onCancel={() => setIsUpdateNodeModalOpen(false)}
           />
         )}
+        <DownloadRemotesAccessClientModal
+          isOpen={isDownloadRemoteAccessClientModalOpen}
+          onCancel={() => setIsDownloadRemoteAccessClientModalOpen(false)}
+          networkId={networkId}
+        />
       </Layout.Content>
       {/* {getNetworkSuggestionsBasedOnUsecase} */}
       {handleQuickSetupModal}

--- a/src/pages/networks/NetworkDetailsPage.tsx
+++ b/src/pages/networks/NetworkDetailsPage.tsx
@@ -97,13 +97,13 @@ import ClientConfigModal from '@/components/modals/client-config-modal/ClientCon
 import { isSaasBuild } from '@/services/BaseService';
 import { NetworkDetailTourStep } from '@/utils/Types';
 import TourComponent, { JumpToTourStepObj } from '@/pages/networks/TourComponent';
-import DownloadRemotesAccessClientModal from '@/components/modals/remote-access-client-modal/DownloadRemoteAccessClientModal';
 import AddRemoteAccessGatewayModal from '@/components/modals/add-remote-access-gateway-modal/AddRemoteAccessGatewayModal';
 import { InternetGatewaysPage } from './internet-gateways/InternetGatewaysPage';
 import { AvailableOses } from '@/models/AvailableOses';
 import { NetworkUsage, networkUsecaseMap } from '@/constants/NetworkUseCases';
 import { NetworkUsecaseString } from '@/store/networkusecase';
 import QuickSetupModal from '@/components/modals/quick-setup-modal/QuickSetupModal';
+import { ExternalLinks } from '@/constants/LinkAndImageConstants';
 
 interface ExternalRoutesTableData {
   node: ExtendedNode;
@@ -2467,14 +2467,15 @@ export default function NetworkDetailsPage(props: PageProps) {
                   }}
                 >
                   <span>
-                    Introducing the Remote Access Client (RAC) – a graphical user interface (GUI) tool designed for
+                    Introducing the Remote Access Client (RAC) - a graphical user interface (GUI) tool designed for
                     convenient connectivity to a Netmaker network. RAC is particularly well-suited for offsite machines
-                    requiring access to a Netmaker network and is compatible with Windows, Mac, and Linux operating
-                    systems.
+                    requiring access to a Netmaker network and is compatible with Windows, Mac, Linux and mobile
+                    (Android, iOS) operating systems.
                   </span>
                   <Button
-                    href="#"
-                    onClick={() => setIsDownloadRemoteAccessClientModalOpen(true)}
+                    href={ExternalLinks.RAC_DOWNLOAD_DOCS_LINK}
+                    target="_blank"
+                    rel="noreferrer"
                     type="primary"
                     style={{
                       marginLeft: 'auto',
@@ -4215,11 +4216,6 @@ export default function NetworkDetailsPage(props: PageProps) {
             onCancel={() => setIsUpdateNodeModalOpen(false)}
           />
         )}
-        <DownloadRemotesAccessClientModal
-          isOpen={isDownloadRemoteAccessClientModalOpen}
-          onCancel={() => setIsDownloadRemoteAccessClientModalOpen(false)}
-          networkId={networkId}
-        />
       </Layout.Content>
       {/* {getNetworkSuggestionsBasedOnUsecase} */}
       {handleQuickSetupModal}


### PR DESCRIPTION
this PR points the user to the RAC docs for download/install instructions.
it also adds missing IPv6 endpoint fields in host update and "add existing host" screens